### PR TITLE
Mark NullCodable as Sendable

### DIFF
--- a/Sources/NullCodable/NullCodable.swift
+++ b/Sources/NullCodable/NullCodable.swift
@@ -50,6 +50,7 @@ extension NullCodable: Decodable where Wrapped: Decodable {
 }
 
 extension NullCodable: Equatable where Wrapped: Equatable { }
+extension NullCodable: Sendable where Wrapped: Sendable { }
 
 extension KeyedDecodingContainer {
     


### PR DESCRIPTION
This is more easily done in the package itself so as to avoid `@preconcurrency` or `@unchecked` attributes.